### PR TITLE
Nearby events list mode

### DIFF
--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventActivityTest.java
@@ -11,7 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.sdpteam.connectout.R;
-import com.sdpteam.connectout.map.MapViewFragment;
+import com.sdpteam.connectout.event.nearbyEvents.map.EventsMapViewFragment;
+import com.sdpteam.connectout.event.viewer.EventActivity;
 
 import android.widget.Button;
 import androidx.fragment.app.Fragment;
@@ -40,7 +41,7 @@ public class EventActivityTest {
     public void fragmentIsCorrectlyAdded() {
         activityRule.getScenario().onActivity(activity -> {
             final Fragment fragment = activity.getSupportFragmentManager().findFragmentById(R.id.event_fragment_container);
-            Assert.assertTrue(fragment instanceof MapViewFragment);
+            Assert.assertTrue(fragment instanceof EventsMapViewFragment);
         });
     }
 

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventCreatorActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventCreatorActivityTest.java
@@ -16,8 +16,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.sdpteam.connectout.R;
-import com.sdpteam.connectout.map.GPSCoordinates;
-import com.sdpteam.connectout.map.PositionSelectorFragment;
+import com.sdpteam.connectout.event.creator.EventCreatorActivity;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
+import com.sdpteam.connectout.event.creator.LocationPicker;
 import com.sdpteam.connectout.profile.EditProfileActivity;
 
 import android.widget.Button;
@@ -60,7 +61,7 @@ public class EventCreatorActivityTest {
     public void activityIsOpenedBeforeClickingToolbarIcon() {
         activityRule.getScenario().onActivity(activity -> {
             Fragment fragment = activity.getSupportFragmentManager().findFragmentById(R.id.event_creator_fragment_container);
-            Assert.assertTrue(fragment instanceof PositionSelectorFragment);
+            Assert.assertTrue(fragment instanceof LocationPicker);
         });
     }
 

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventCreatorViewModelTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventCreatorViewModelTest.java
@@ -13,7 +13,8 @@ import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.creator.EventCreatorViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 import com.sdpteam.connectout.utils.LiveDataTestUtil;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventFirebaseDataSourceTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventFirebaseDataSourceTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 import com.sdpteam.connectout.profile.EditProfileActivity;
 
 public class EventFirebaseDataSourceTest {

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 
 import com.google.android.gms.maps.model.LatLng;
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 
 public class EventTest {
 

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
@@ -3,9 +3,19 @@ package com.sdpteam.connectout.event;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.equalTo;
 
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,7 +24,9 @@ import org.junit.runner.RunWith;
 
 import com.sdpteam.connectout.R;
 import com.sdpteam.connectout.event.nearbyEvents.EventsActivity;
+import com.sdpteam.connectout.profile.ProfileActivity;
 
+import android.view.View;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -54,5 +66,53 @@ public class EventsActivityTest {
         onView(withId(R.id.event_list)).check(matches(isDisplayed()));
         onView(withId(R.id.map_switch_button)).perform(click());
         onView(withId(R.id.map)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void firstEventInTheListHasCorrectTitleAndDescription() {
+        onView(withId(R.id.list_switch_button)).perform(click());
+        onView(withId(R.id.event_list)).check(matches(isDisplayed()));
+        onView(withId(R.id.events_list_view)).check(matches(isDisplayed()));
+        List<Event> events = new EventFirebaseDataSource().getEventsByFilter(null, null).join();
+        String expectedTitle = events.get(0).getTitle();
+        String expectedDescription = events.get(0).getDescription();
+        onView(withIndex(withId(R.id.event_list_event_title), 0)).check(matches(withText(expectedTitle)));
+        onView(withIndex(withId(R.id.event_list_event_description), 0)).check(matches(withText(expectedDescription)));
+    }
+
+    @Test
+    public void clickingOrganizorProfileInTheListTriggersIntent() {
+        onView(withId(R.id.list_switch_button)).perform(click());
+        onView(withId(R.id.event_list)).check(matches(isDisplayed()));
+        onView(withId(R.id.events_list_view)).check(matches(isDisplayed()));
+        List<Event> events = new EventFirebaseDataSource().getEventsByFilter(null, null).join();
+        String expectedOrganizer = events.get(0).getOrganizer();
+        onView(withIndex(withId(R.id.event_list_profile_button), 0)).perform(click());
+        intended(Matchers.allOf(hasComponent(ProfileActivity.class.getName()), hasExtra(equalTo("uid"), equalTo(expectedOrganizer))));
+    }
+
+    static Matcher<View> withIndex(final Matcher<View> matcher, final int index) {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(org.hamcrest.Description description) {
+                description.appendText("with index: ");
+                description.appendValue(index);
+                matcher.describeTo(description);
+            }
+
+            int currentIndex = 0;
+
+            @Override
+            public boolean matchesSafely(View view) {
+                if (matcher.matches(view)) {
+                    if (currentIndex == index) {
+                        currentIndex++;
+                        return true;
+                    }
+                    currentIndex++;
+                }
+                return false;
+            }
+        };
     }
 }

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.sdpteam.connectout.R;
+import com.sdpteam.connectout.event.nearbyEvents.EventsActivity;
 
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventsViewModelFactoryTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventsViewModelFactoryTest.java
@@ -12,7 +12,9 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModelFactory;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 import com.sdpteam.connectout.profile.ProfileViewModel;
 import com.sdpteam.connectout.utils.LiveDataTestUtil;
 

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventsViewModelTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventsViewModelTest.java
@@ -10,7 +10,8 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 import com.sdpteam.connectout.utils.LiveDataTestUtil;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
@@ -38,7 +39,7 @@ public class EventsViewModelTest {
         LiveDataTestUtil.getOrAwaitValue(mvm.getEventListLiveData());
 
         LiveData<List<Event>> liveData = mvm.getEventListLiveData();
-        mvm.refreshEventList();
+        mvm.refreshEvents();
         List<Event> eventList = LiveDataTestUtil.getOrAwaitValue(liveData);
 
         assertThat(eventList.size(), is(3));

--- a/app/src/androidTest/java/com/sdpteam/connectout/map/GPSCoordinatesTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/map/GPSCoordinatesTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThrows;
 import org.junit.Test;
 
 import com.google.android.gms.maps.model.LatLng;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 
 public class GPSCoordinatesTest {
     private final static LatLng VALID_POSITION = new LatLng(37.7749, -122.4194);

--- a/app/src/androidTest/java/com/sdpteam/connectout/map/MapFragmentTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/map/MapFragmentTest.java
@@ -15,9 +15,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.sdpteam.connectout.R;
-import com.sdpteam.connectout.event.EventCreatorActivity;
+import com.sdpteam.connectout.event.creator.EventCreatorActivity;
 import com.sdpteam.connectout.event.EventFirebaseDataSource;
-import com.sdpteam.connectout.event.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.creator.LocationPicker;
 
 import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -48,7 +49,7 @@ public class MapFragmentTest {
 
     @Test
     public void defaultPositionBeforeMarkerInstantiation() {
-        PositionSelectorFragment positionSelectorFragment = new PositionSelectorFragment(new EventsViewModel(new EventFirebaseDataSource()));
+        LocationPicker positionSelectorFragment = new LocationPicker(new EventsViewModel(new EventFirebaseDataSource()));
         assertThat(positionSelectorFragment.getMovingMarkerPosition().latitude, is(0.0));
         assertThat(positionSelectorFragment.getMovingMarkerPosition().longitude, is(0.0));
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             tools:targetApi="31">
 
         <activity
-                android:name=".event.EventsActivity"
+                android:name=".event.nearbyEvents.EventsActivity"
                 android:exported="false" />
 
         <activity
@@ -24,7 +24,7 @@
                 android:name=".registration.CompleteRegistrationActivity"
                 android:exported="false" />
         <activity
-                android:name=".event.EventActivity"
+                android:name=".event.viewer.EventActivity"
                 android:exported="false" />
         <activity
                 android:name=".profile.ProfileActivity"
@@ -35,7 +35,7 @@
                 android:value="AIzaSyA-zOfg_1F76v7EckDDKQndOpbj3xP6HVA" />
 
         <activity
-                android:name=".event.EventCreatorActivity"
+                android:name=".event.creator.EventCreatorActivity"
                 android:exported="false"
                 android:theme="@style/Theme.ConnectOut.NoActionBar" />
 

--- a/app/src/main/java/com/sdpteam/connectout/MainActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/MainActivity.java
@@ -1,6 +1,7 @@
 package com.sdpteam.connectout;
 
 import com.sdpteam.connectout.authentication.GoogleLoginActivity;
+import com.sdpteam.connectout.event.nearbyEvents.EventsActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -13,7 +14,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         // Don't put anything here, just choose which activity to redirect to
-        Intent drawerIntent = new Intent(getApplicationContext(), GoogleLoginActivity.class);
+        Intent drawerIntent = new Intent(getApplicationContext(), EventsActivity.class);
         this.startActivity(drawerIntent);
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/MainActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/MainActivity.java
@@ -1,7 +1,6 @@
 package com.sdpteam.connectout;
 
 import com.sdpteam.connectout.authentication.GoogleLoginActivity;
-import com.sdpteam.connectout.event.nearbyEvents.EventsActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -14,7 +13,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         // Don't put anything here, just choose which activity to redirect to
-        Intent drawerIntent = new Intent(getApplicationContext(), EventsActivity.class);
+        Intent drawerIntent = new Intent(getApplicationContext(), GoogleLoginActivity.class);
         this.startActivity(drawerIntent);
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/event/Event.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/Event.java
@@ -5,7 +5,7 @@ import static com.sdpteam.connectout.profile.EditProfileActivity.NULL_USER;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sdpteam.connectout.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 
 /**
  * This class describes an event

--- a/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorActivity.java
@@ -1,10 +1,11 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.creator;
 
 import com.sdpteam.connectout.R;
 import com.sdpteam.connectout.authentication.AuthenticatedUser;
 import com.sdpteam.connectout.authentication.GoogleAuth;
-import com.sdpteam.connectout.map.GPSCoordinates;
-import com.sdpteam.connectout.map.PositionSelectorFragment;
+import com.sdpteam.connectout.event.Event;
+import com.sdpteam.connectout.event.EventFirebaseDataSource;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 import com.sdpteam.connectout.profile.EditProfileActivity;
 import com.sdpteam.connectout.utils.WithFragmentActivity;
 
@@ -28,7 +29,7 @@ public class EventCreatorActivity extends WithFragmentActivity {
         Toolbar toolbar = findViewById(R.id.event_creator_toolbar);
         setSupportActionBar(toolbar);
 
-        PositionSelectorFragment mapFragment = new PositionSelectorFragment(eventCreatorViewModel);
+        LocationPicker mapFragment = new LocationPicker(eventCreatorViewModel);
         replaceFragment(mapFragment, R.id.event_creator_fragment_container);
 
         toolbar.setNavigationOnClickListener(v -> this.finish());
@@ -38,12 +39,11 @@ public class EventCreatorActivity extends WithFragmentActivity {
         EditText eventTitle = findViewById(R.id.event_creator_title);
         EditText eventDescription = findViewById(R.id.event_creator_description);
 
-        saveButton.setOnClickListener(v ->
-        {
-            saveEvent(eventTitle.getText().toString(),
-                    new GPSCoordinates(mapFragment.getMovingMarkerPosition()),
-                    eventDescription.getText().toString()
-            );
+        saveButton.setOnClickListener(v -> {
+            final String chosenTitle = eventTitle.getText().toString();
+            final GPSCoordinates chosenCoordinates = new GPSCoordinates(mapFragment.getMovingMarkerPosition());
+            final String chosenDescription = eventDescription.getText().toString();
+            saveEvent(chosenTitle, chosenCoordinates, chosenDescription);
             this.finish();
         });
     }
@@ -60,13 +60,7 @@ public class EventCreatorActivity extends WithFragmentActivity {
         String ownerId = user == null ? EditProfileActivity.NULL_USER : user.uid;
 
         //Create associated event.
-        Event newEvent = new Event(
-                eventCreatorViewModel.getUniqueId(),
-                title,
-                description,
-                coordinates,
-                ownerId
-        );
+        Event newEvent = new Event(eventCreatorViewModel.getUniqueId(), title, description, coordinates, ownerId);
 
         //Save the event & return to previous activity.
         eventCreatorViewModel.saveEvent(newEvent);

--- a/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorViewModel.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorViewModel.java
@@ -1,4 +1,8 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.creator;
+
+import com.sdpteam.connectout.event.Event;
+import com.sdpteam.connectout.event.EventRepository;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
 
 import androidx.lifecycle.MutableLiveData;
 

--- a/app/src/main/java/com/sdpteam/connectout/event/creator/LocationPicker.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/creator/LocationPicker.java
@@ -1,4 +1,4 @@
-package com.sdpteam.connectout.map;
+package com.sdpteam.connectout.event.creator;
 
 import static com.google.android.gms.maps.GoogleMap.OnMarkerDragListener;
 
@@ -12,26 +12,28 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.sdpteam.connectout.event.Event;
-import com.sdpteam.connectout.event.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.map.EventsMapViewFragment;
 
 import androidx.annotation.NonNull;
 
-public class PositionSelectorFragment extends MapViewFragment implements OnMapReadyCallback {
+// TODO : it is very strange to make a fragment extend another one. especially when they have different purposes.
+public class LocationPicker extends EventsMapViewFragment implements OnMapReadyCallback {
 
     //Movable marker used to get event location
     private Marker movingMarker;
     private GoogleMap map;
 
-    public PositionSelectorFragment(EventsViewModel mapViewModel) {
+    public LocationPicker(EventsViewModel mapViewModel) {
         super(mapViewModel);
     }
 
     @Override
-    public void showNewMarkerList(List<Event> eventList) {
+    public void showEventsOnMap(List<Event> eventList) {
         if (map == null) {
             return;
         }
-        super.showNewMarkerList(eventList);
+        super.showEventsOnMap(eventList);
         MarkerOptions markerOptions = new MarkerOptions()
                 .position(getMovingMarkerPosition())
                 .draggable(true)

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsActivity.java
@@ -25,18 +25,19 @@ public class EventsActivity extends WithFragmentActivity {
 
         EventsViewModel viewModel = new ViewModelProvider(this, new EventsViewModelFactory(new EventFirebaseDataSource())).get(EventsViewModel.class);
         eventsMapViewFragment = new EventsMapViewFragment(viewModel);
-        eventsListViewFragment = new EventsListViewFragment();
-        replaceFragment(eventsMapViewFragment, R.id.events_map_list_container);
+        eventsListViewFragment = new EventsListViewFragment(viewModel);
+
+        replaceFragment(eventsMapViewFragment, R.id.nearby_events_container);
         RadioButton mapButton = findViewById(R.id.map_switch_button);
         RadioButton listButton = findViewById(R.id.list_switch_button);
 
         mapListButton.setOnCheckedChangeListener((buttonView, isChecked) -> {
                     if (R.id.map_switch_button == isChecked) {
                         listButton.setChecked(false);
-                        replaceFragment(eventsMapViewFragment, R.id.events_map_list_container);
+                        replaceFragment(eventsMapViewFragment, R.id.nearby_events_container);
                     } else {
                         mapButton.setChecked(false);
-                        replaceFragment(eventsListViewFragment, R.id.events_map_list_container);
+                        replaceFragment(eventsListViewFragment, R.id.nearby_events_container);
                     }
                 }
 

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsActivity.java
@@ -1,8 +1,9 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.nearbyEvents;
 
 import com.sdpteam.connectout.R;
-import com.sdpteam.connectout.eventList.ListViewFragment;
-import com.sdpteam.connectout.map.MapViewFragment;
+import com.sdpteam.connectout.event.EventFirebaseDataSource;
+import com.sdpteam.connectout.event.nearbyEvents.list.EventsListViewFragment;
+import com.sdpteam.connectout.event.nearbyEvents.map.EventsMapViewFragment;
 import com.sdpteam.connectout.utils.WithFragmentActivity;
 
 import android.os.Bundle;
@@ -12,8 +13,8 @@ import androidx.lifecycle.ViewModelProvider;
 
 public class EventsActivity extends WithFragmentActivity {
 
-    private MapViewFragment mapViewFragment;
-    private ListViewFragment listViewFragment;
+    private EventsMapViewFragment eventsMapViewFragment;
+    private EventsListViewFragment eventsListViewFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,19 +24,19 @@ public class EventsActivity extends WithFragmentActivity {
         RadioGroup mapListButton = findViewById(R.id.events_switch);
 
         EventsViewModel viewModel = new ViewModelProvider(this, new EventsViewModelFactory(new EventFirebaseDataSource())).get(EventsViewModel.class);
-        mapViewFragment = new MapViewFragment(viewModel);
-        listViewFragment = new ListViewFragment();
-        replaceFragment(mapViewFragment, R.id.events_map_list_container);
+        eventsMapViewFragment = new EventsMapViewFragment(viewModel);
+        eventsListViewFragment = new EventsListViewFragment();
+        replaceFragment(eventsMapViewFragment, R.id.events_map_list_container);
         RadioButton mapButton = findViewById(R.id.map_switch_button);
         RadioButton listButton = findViewById(R.id.list_switch_button);
 
         mapListButton.setOnCheckedChangeListener((buttonView, isChecked) -> {
                     if (R.id.map_switch_button == isChecked) {
                         listButton.setChecked(false);
-                        replaceFragment(mapViewFragment, R.id.events_map_list_container);
+                        replaceFragment(eventsMapViewFragment, R.id.events_map_list_container);
                     } else {
                         mapButton.setChecked(false);
-                        replaceFragment(listViewFragment, R.id.events_map_list_container);
+                        replaceFragment(eventsListViewFragment, R.id.events_map_list_container);
                     }
                 }
 

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsViewModel.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsViewModel.java
@@ -1,7 +1,10 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.nearbyEvents;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.sdpteam.connectout.event.Event;
+import com.sdpteam.connectout.event.EventRepository;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
@@ -17,14 +20,14 @@ public class EventsViewModel extends ViewModel {
     public EventsViewModel(EventRepository model) {
         this.model = model;
         events = new MutableLiveData<>(new ArrayList<>());
-        refreshEventList();
+        refreshEvents();
     }
 
     public LiveData<List<Event>> getEventListLiveData() {
         return events;
     }
 
-    public void refreshEventList() {
+    public void refreshEvents() {
         model.getEventsByFilter(null, null).thenAccept(events::setValue);
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsViewModelFactory.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/EventsViewModelFactory.java
@@ -1,4 +1,6 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.nearbyEvents;
+
+import com.sdpteam.connectout.event.EventRepository;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
@@ -1,0 +1,78 @@
+package com.sdpteam.connectout.event.nearbyEvents.list;
+
+import java.util.List;
+
+import com.sdpteam.connectout.R;
+import com.sdpteam.connectout.event.Event;
+import com.sdpteam.connectout.profile.ProfileActivity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * It is responsible for creating and managing the views for a list of events.
+ * The class holds the context, resource, and a list of events, which are passed in through the constructor.
+ */
+public class EventsAdapter extends ArrayAdapter<Event> {
+
+    private final Context context;
+    private final int resource;
+
+    /**
+     * @param context  The context in which the adapter is being used.
+     * @param resource The resource ID for the layout file of each list item.
+     * @param events   The list of events to display in the ListView.
+     */
+    public EventsAdapter(@NonNull Context context, int resource, @NonNull List<Event> events) {
+        super(context, resource, events);
+        this.context = context;
+        this.resource = resource;
+    }
+
+    /**
+     * Creating and returning the view for each list item.
+     */
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view = convertView;
+        if (view == null) {
+            LayoutInflater inflater = LayoutInflater.from(context);
+            view = inflater.inflate(resource, parent, false);
+        }
+
+        Event event = getItem(position);
+
+        TextView eventTitle = view.findViewById(R.id.event_list_event_title);
+        eventTitle.setText(event.getTitle());
+
+        TextView eventDescription = view.findViewById(R.id.event_list_event_description);
+        eventDescription.setText(event.getDescription());
+
+        ImageButton profileImageButton = view.findViewById(R.id.event_list_profile_button);
+        profileImageButton.setOnClickListener(v -> {
+            openProfile(event.getOrganizer());
+        });
+
+        ImageView eventImage = view.findViewById(R.id.event_list_event_image);
+        //TODO set images
+
+        return view;
+    }
+
+    private void openProfile(String profileId) {
+        Intent intent = new Intent(context, ProfileActivity.class);
+        intent.putExtra("uid", profileId);
+        context.startActivity(intent);
+    }
+}
+

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
@@ -24,18 +24,16 @@ import androidx.annotation.Nullable;
  */
 public class EventsAdapter extends ArrayAdapter<Event> {
 
-    private final Context context;
-    private final int resource;
+    private final int eventListItemResource;
 
     /**
-     * @param context  The context in which the adapter is being used.
-     * @param resource The resource ID for the layout file of each list item.
-     * @param events   The list of events to display in the ListView.
+     * @param context               The context in which the adapter is being used.
+     * @param eventListItemResource The resource ID for the layout file of each list item.
+     * @param events                The list of events to display in the ListView.
      */
-    public EventsAdapter(@NonNull Context context, int resource, @NonNull List<Event> events) {
-        super(context, resource, events);
-        this.context = context;
-        this.resource = resource;
+    public EventsAdapter(@NonNull Context context, int eventListItemResource, @NonNull List<Event> events) {
+        super(context, eventListItemResource, events);
+        this.eventListItemResource = eventListItemResource;
     }
 
     /**
@@ -46,8 +44,8 @@ public class EventsAdapter extends ArrayAdapter<Event> {
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
         View view = convertView;
         if (view == null) {
-            LayoutInflater inflater = LayoutInflater.from(context);
-            view = inflater.inflate(resource, parent, false);
+            LayoutInflater inflater = LayoutInflater.from(getContext());
+            view = inflater.inflate(eventListItemResource, parent, false);
         }
 
         Event event = getItem(position);
@@ -70,9 +68,9 @@ public class EventsAdapter extends ArrayAdapter<Event> {
     }
 
     private void openProfile(String profileId) {
-        Intent intent = new Intent(context, ProfileActivity.class);
+        Intent intent = new Intent(getContext(), ProfileActivity.class);
         intent.putExtra("uid", profileId);
-        context.startActivity(intent);
+        getContext().startActivity(intent);
     }
 }
 

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsListViewFragment.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsListViewFragment.java
@@ -1,4 +1,4 @@
-package com.sdpteam.connectout.eventList;
+package com.sdpteam.connectout.event.nearbyEvents.list;
 
 import com.sdpteam.connectout.R;
 
@@ -12,7 +12,7 @@ import androidx.fragment.app.Fragment;
 
 //TODO Issue #37 of the sprint.
 
-public class ListViewFragment extends Fragment {
+public class EventsListViewFragment extends Fragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsListViewFragment.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsListViewFragment.java
@@ -1,21 +1,37 @@
 package com.sdpteam.connectout.event.nearbyEvents.list;
 
 import com.sdpteam.connectout.R;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-//TODO Issue #37 of the sprint.
-
 public class EventsListViewFragment extends Fragment {
+
+    private final EventsViewModel eventsViewModel;
+
+    public EventsListViewFragment(EventsViewModel eventsViewModel) {
+        this.eventsViewModel = eventsViewModel;
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_event_list, container, false);
+        View contentView = inflater.inflate(R.layout.fragment_event_list, container, false);
+
+        eventsViewModel.refreshEvents();
+
+        eventsViewModel.getEventListLiveData().observeForever(events -> {
+            EventsAdapter adapter = new EventsAdapter(container.getContext(), R.layout.event_list_item_view, events);
+            ListView listView = contentView.findViewById(R.id.events_list_view);
+            listView.setAdapter(adapter);
+        });
+
+        return contentView;
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/map/EventsMapViewFragment.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/map/EventsMapViewFragment.java
@@ -1,4 +1,4 @@
-package com.sdpteam.connectout.map;
+package com.sdpteam.connectout.event.nearbyEvents.map;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,7 +9,7 @@ import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.sdpteam.connectout.R;
 import com.sdpteam.connectout.event.Event;
-import com.sdpteam.connectout.event.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -20,14 +20,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-public class MapViewFragment extends Fragment implements OnMapReadyCallback {
+public class EventsMapViewFragment extends Fragment implements OnMapReadyCallback {
 
     private static final int DEFAULT_MAP_ZOOM = 15;
-    private final EventsViewModel mapViewModel;
+    private final EventsViewModel eventsViewModel;
     private GoogleMap map;
 
-    public MapViewFragment(EventsViewModel mapViewModel) {
-        this.mapViewModel = mapViewModel;
+    public EventsMapViewFragment(EventsViewModel eventsViewModel) {
+        this.eventsViewModel = eventsViewModel;
     }
 
     @Nullable
@@ -35,22 +35,20 @@ public class MapViewFragment extends Fragment implements OnMapReadyCallback {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_map, container, false);
 
-        // Obtain the SupportMapFragment and get notified when the map is ready to be used.
-        //container object for the map used for the map lifecycle management and UI capabilities
         SupportMapFragment mapFragment = (SupportMapFragment) getChildFragmentManager().findFragmentById(R.id.map);
-        mapFragment.getMapAsync(this);
+        mapFragment.getMapAsync(this); // callback to call when the map is ready
 
-        mapViewModel.refreshEventList();
+        eventsViewModel.refreshEvents();
 
-        mapViewModel.getEventListLiveData().observe(getViewLifecycleOwner(), this::showNewMarkerList);
+        eventsViewModel.getEventListLiveData().observe(getViewLifecycleOwner(), this::showEventsOnMap);
 
         ImageButton refreshButton = rootView.findViewById(R.id.refresh_button);
-        refreshButton.setOnClickListener(view -> mapViewModel.refreshEventList());
+        refreshButton.setOnClickListener(view -> eventsViewModel.refreshEvents());
 
         return rootView;
     }
 
-    public void showNewMarkerList(List<Event> eventList) {
+    public void showEventsOnMap(List<Event> eventList) {
         if (map == null) {
             return;
         }

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/map/GPSCoordinates.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/map/GPSCoordinates.java
@@ -1,4 +1,4 @@
-package com.sdpteam.connectout.map;
+package com.sdpteam.connectout.event.nearbyEvents.map;
 
 import com.google.android.gms.maps.model.LatLng;
 

--- a/app/src/main/java/com/sdpteam/connectout/event/viewer/EventActivity.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/viewer/EventActivity.java
@@ -1,4 +1,4 @@
-package com.sdpteam.connectout.event;
+package com.sdpteam.connectout.event.viewer;
 
 import static java.lang.String.format;
 
@@ -8,8 +8,12 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 import com.sdpteam.connectout.R;
-import com.sdpteam.connectout.map.GPSCoordinates;
-import com.sdpteam.connectout.map.MapViewFragment;
+import com.sdpteam.connectout.event.Event;
+import com.sdpteam.connectout.event.EventRepository;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.EventsViewModelFactory;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
+import com.sdpteam.connectout.event.nearbyEvents.map.EventsMapViewFragment;
 import com.sdpteam.connectout.utils.WithFragmentActivity;
 
 import android.os.Bundle;
@@ -76,7 +80,7 @@ public class EventActivity extends WithFragmentActivity {
         // Implicitly instantiating EventsViewModel to use that instance back in MapViewFragment
         final EventsViewModel mapViewModel = new ViewModelProvider(this, new EventsViewModelFactory(mapModel)).get(EventsViewModel.class);
 
-        final MapViewFragment map = new MapViewFragment(mapViewModel);
+        final EventsMapViewFragment map = new EventsMapViewFragment(mapViewModel);
         replaceFragment(map, R.id.event_fragment_container);
     }
 

--- a/app/src/main/res/drawable/mountain_image.xml
+++ b/app/src/main/res/drawable/mountain_image.xml
@@ -1,0 +1,5 @@
+<vector android:height="50dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="50dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -4,7 +4,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".event.EventActivity">
+        tools:context=".event.viewer.EventActivity">
 
     <RelativeLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_event_creator.xml
+++ b/app/src/main/res/layout/activity_event_creator.xml
@@ -5,7 +5,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:id="@+id/event_creator_id"
-        tools:context=".event.EventCreatorActivity">
+        tools:context=".event.creator.EventCreatorActivity">
 
     <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/event_creator_appbar"

--- a/app/src/main/res/layout/activity_events.xml
+++ b/app/src/main/res/layout/activity_events.xml
@@ -44,7 +44,7 @@
 
 
     <FrameLayout
-            android:id="@+id/events_map_list_container"
+            android:id="@+id/nearby_events_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_above="@+id/events_task_bar"

--- a/app/src/main/res/layout/activity_events.xml
+++ b/app/src/main/res/layout/activity_events.xml
@@ -4,7 +4,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:id="@+id/events_activity_id"
-        tools:context=".event.EventsActivity">
+        tools:context=".event.nearbyEvents.EventsActivity">
 
     <RadioGroup
             android:id="@+id/events_switch"

--- a/app/src/main/res/layout/event_list_item_view.xml
+++ b/app/src/main/res/layout/event_list_item_view.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="4">
+
+    <!-- Profile Picture on the left -->
+    <ImageButton
+            android:id="@+id/event_list_profile_button"
+            android:layout_height="match_parent"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:src="@drawable/account_image"
+            android:background="@color/white" />
+
+    <!-- Event Title and Description in the middle -->
+    <LinearLayout
+            android:id="@+id/event_details_layout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:paddingHorizontal="16dp"
+            android:orientation="vertical">
+
+        <!-- Event Title -->
+        <TextView
+                android:id="@+id/event_list_event_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:text="Event Title, join us!" />
+
+        <!-- Event Description -->
+        <TextView
+                android:id="@+id/event_list_event_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginTop="8dp"
+                android:text="My awesome event description here that is very long because why not" />
+    </LinearLayout>
+
+    <!-- Event Image on the right -->
+    <ImageView
+            android:id="@+id/event_list_event_image"
+            android:scaleType="fitCenter"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:src="@drawable/mountain_image"
+            android:background="@color/white" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_event_list.xml
+++ b/app/src/main/res/layout/fragment_event_list.xml
@@ -5,7 +5,7 @@
         android:layout_height="match_parent"
         tools:viewBindingIgnore="true"
         android:id="@+id/event_list"
-        tools:context=".eventList.ListViewFragment">
+        tools:context=".event.nearbyEvents.list.EventsListViewFragment">
 
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_event_list.xml
+++ b/app/src/main/res/layout/fragment_event_list.xml
@@ -1,11 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:viewBindingIgnore="true"
         android:id="@+id/event_list"
         tools:context=".event.nearbyEvents.list.EventsListViewFragment">
 
-
+    <ListView
+            android:id="@+id/events_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -5,7 +5,7 @@
         android:layout_height="match_parent"
         tools:viewBindingIgnore="true"
         android:id="@+id/map"
-        tools:context=".map.MapViewFragment"
+        tools:context=".event.nearbyEvents.map.EventsMapViewFragment"
         android:name="com.google.android.gms.maps.SupportMapFragment">
 
     <ImageButton


### PR DESCRIPTION
- The EventsActivity has now the map and list view modes, all data is fetched from Firebase. Only those that have positions will be visible in Map mode, whereas all events are listed in the List mode.
- The UI is responsive
- From the list we can open profile page of the organiser by clicking on his profile image
- Reorganised all the files into coherent subfolders in `event` folder