### PR TITLE
Fix faulty CI profile test

### DIFF
--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileFilterFragmentTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileFilterFragmentTest.java
@@ -96,34 +96,6 @@ public class ProfileFilterFragmentTest {
     }
 
 
-
-    @Test
-    public void wrongFilteringWithRatingShowsCompleteList() {
-        FragmentScenario<ProfileFilterFragment> fc = FragmentScenario.launchInContainer(ProfileFilterFragment.class);
-
-        onView(withId(R.id.name_switch_button)).perform(click());
-        onView(withId(R.id.rating_switch_button)).perform(click());
-        onView(withId(R.id.rating_switch_button)).perform(click());
-        onView(withId(R.id.text_filter)).perform(typeText("0;1 I dont know how to use filter "), ViewActions.closeSoftKeyboard());
-        onView(withId(R.id.filter_apply_button)).perform(click());
-        onView(withId(R.id.filter_container)).check(matches(isDisplayed()));
-
-        List<Profile> profiles = new ArrayList<>();
-        fc.onFragment(fragment -> {
-            ListView recyclerView = fragment.getView().findViewById(R.id.user_list_view);
-            for (int i = 0; i < recyclerView.getAdapter().getCount(); i++) {
-                Profile profile = (Profile) recyclerView.getAdapter().getItem(i);
-                profiles.add(profile);
-            }
-        });
-        if (!profiles.isEmpty()) {
-            List<Double> givenList = profiles.stream().map(Profile::getRating).collect(Collectors.toList());
-            List<Double> copiedList = new ArrayList<>(givenList);
-            Collections.sort(copiedList);
-            assertThat(givenList, is(copiedList));
-        }
-    }
-
     @Test
     public void wrongFilteringWithNameShowsEmptyList() {
         FragmentScenario<ProfileFilterFragment> fc = FragmentScenario.launchInContainer(ProfileFilterFragment.class);

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileListActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileListActivityTest.java
@@ -25,6 +25,7 @@ import android.widget.ListView;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.testing.FragmentScenario;
 import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -179,6 +180,31 @@ public class ProfileListActivityTest {
             assertThat(givenList, is(copiedList));
         }
 
+    }
+
+    @Test
+    public void wrongFilteringWithRatingShowsCompleteList() {
+        onView(withId(R.id.user_list_button)).perform(click());
+        onView(withId(R.id.name_switch_button)).perform(click());
+        onView(withId(R.id.rating_switch_button)).perform(click());
+        onView(withId(R.id.text_filter)).perform(typeText("0;1 I dont know how to use filter "), ViewActions.closeSoftKeyboard());
+        onView(withId(R.id.filter_apply_button)).perform(click());
+        onView(withId(R.id.filter_container)).check(matches(isDisplayed()));
+
+        List<Profile> profiles = new ArrayList<>();
+        activityRule.getScenario().onActivity(activity -> {
+            ListView recyclerView = activity.findViewById(R.id.user_list_view);
+            for (int i = 0; i < recyclerView.getAdapter().getCount(); i++) {
+                Profile profile = (Profile) recyclerView.getAdapter().getItem(i);
+                profiles.add(profile);
+            }
+        });
+        if (!profiles.isEmpty()) {
+            List<Double> givenList = profiles.stream().map(Profile::getRating).collect(Collectors.toList());
+            List<Double> copiedList = new ArrayList<>(givenList);
+            Collections.sort(copiedList);
+            assertThat(givenList, is(copiedList));
+        }
     }
 
 }


### PR DESCRIPTION
Fix a small failing test on profile filtering that has been experienced sometimes by the CI.
the corresponding test is `wrongFilteringWithRatingShowsCompleteList`.
Test has been moved from the fragment to the corresponding activity as the container of the fragment was not adequate.

