### PR TITLE
(#147) Fix bug when filtering the profiles in the event participants list

### DIFF
--- a/app/src/androidTest/java/com/sdpteam/connectout/profile/ProfileEntryTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profile/ProfileEntryTest.java
@@ -1,0 +1,34 @@
+package com.sdpteam.connectout.profile;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class ProfileEntryTest {
+
+    @Test
+    public void testGetProfile() {
+        final Profile profile = new Profile("1", "name", "email", "bio", Profile.Gender.MALE, 5, 1, "");
+        final ProfileEntry entry = new ProfileEntry(profile, new ArrayList<>());
+        assertEquals(profile, entry.getProfile());
+    }
+
+    @Test
+    public void testGetRegisteredEvents() {
+        final List<RegisteredEvent> events = new ArrayList<>();
+        events.add(new RegisteredEvent(1, "1", "title 1"));
+        events.add(new RegisteredEvent(2, "2", "title 2"));
+        final ProfileEntry entry = new ProfileEntry(Profile.NULL_PROFILE, events);
+
+        assertEquals(events.size(), entry.getRegisteredEvents().size());
+        assertEquals(events.get(0).getEventId(), "1");
+        assertEquals(events.get(1).getEventId(), "2");
+    }
+}

--- a/app/src/androidTest/java/com/sdpteam/connectout/profile/RegisteredEventTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profile/RegisteredEventTest.java
@@ -1,0 +1,38 @@
+package com.sdpteam.connectout.profile;
+
+import static com.sdpteam.connectout.profile.RegisteredEvent.NULL_REGISTERED_EVENT;
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class RegisteredEventTest {
+
+    @Test
+    public void testGetEventDate() {
+        final RegisteredEvent registeredEvent = new RegisteredEvent(1, "id", "title");
+        assertEquals(1, registeredEvent.getEventDate());
+    }
+
+    @Test
+    public void testGetEventId() {
+        final RegisteredEvent registeredEvent = new RegisteredEvent(1, "id", "title");
+        assertEquals("id", registeredEvent.getEventId());
+    }
+
+    @Test
+    public void testGetEventTitle() {
+        final RegisteredEvent registeredEvent = new RegisteredEvent(1, "id", "title");
+        assertEquals("title", registeredEvent.getEventTitle());
+    }
+
+    @Test
+    public void testNullRegisteredEvent() {
+        assertEquals(0, NULL_REGISTERED_EVENT.getEventDate());
+        assertEquals("", NULL_REGISTERED_EVENT.getEventId());
+        assertEquals("", NULL_REGISTERED_EVENT.getEventTitle());
+    }
+}

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/CommunityActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/CommunityActivityTest.java
@@ -130,17 +130,6 @@ public class CommunityActivityTest {
     }
 
     @Test
-    public void initialViewIsFiltered() {
-        onView(withId(R.id.user_list_button)).check(matches((isDisplayed())));
-    }
-
-    @Test
-    public void getNonFilteredView() {
-        onView(withId(R.id.user_list_button)).perform(click());
-        onView(withId(R.id.container_users_listview)).check(matches(isDisplayed()));
-    }
-
-    @Test
     public void swappingDisplaysFilterView() {
         onView(withId(R.id.filter_container)).check(matches(isDisplayed()));
     }

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileFilterTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileFilterTest.java
@@ -1,0 +1,36 @@
+package com.sdpteam.connectout.profileList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.sdpteam.connectout.profile.Profile;
+import com.sdpteam.connectout.profile.ProfileEntry;
+import com.sdpteam.connectout.profileList.filter.ProfileFilter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+@RunWith(AndroidJUnit4.class)
+public class ProfileFilterTest {
+
+    @Test
+    public void testCombineFiltersWithAnd() {
+        final ProfileFilter f1 = e -> true;
+        final ProfileFilter f2 = e -> false;
+
+        assertTrue(f1.and(f1).test(null));
+        assertFalse(f1.and(f2).test(null));
+        assertFalse(f2.and(f1).test(null));
+        assertFalse(f2.and(f2).test(null));
+    }
+
+    @Test
+    public void testNoneFilterAlwaysMatches() {
+        assertTrue(ProfileFilter.NONE.test(null));
+        assertTrue(ProfileFilter.NONE.test(new ProfileEntry(Profile.NULL_PROFILE, new ArrayList<>())));
+    }
+}

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileNameFilterTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileNameFilterTest.java
@@ -1,0 +1,45 @@
+package com.sdpteam.connectout.profileList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.sdpteam.connectout.profile.Profile;
+import com.sdpteam.connectout.profile.ProfileEntry;
+import com.sdpteam.connectout.profileList.filter.ProfileNameFilter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+@RunWith(AndroidJUnit4.class)
+public class ProfileNameFilterTest {
+
+    @Test
+    public void testNameFilterMatches() {
+        final ProfileNameFilter filter1 = new ProfileNameFilter("ron");
+        final ProfileNameFilter filter2 = new ProfileNameFilter("RON");
+        final ProfileNameFilter filter3 = new ProfileNameFilter("Ronaldo");
+        final ProfileNameFilter filter4 = new ProfileNameFilter("r   ");
+
+        final Profile profile = new Profile("", "Ronaldo", "", "", Profile.Gender.MALE, 0, 0, "");
+        final ProfileEntry entry = new ProfileEntry(profile, new ArrayList<>());
+
+        assertTrue(filter1.test(entry));
+        assertTrue(filter2.test(entry));
+        assertTrue(filter3.test(entry));
+        assertTrue(filter4.test(entry));
+    }
+
+    @Test
+    public void testNameFilterMismatches() {
+        final ProfileNameFilter filter = new ProfileNameFilter("x");
+
+        final Profile profile = new Profile("", "Ronaldo", "", "", Profile.Gender.MALE, 0, 0, "");
+        final ProfileEntry entry = new ProfileEntry(profile, new ArrayList<>());
+
+        assertFalse(filter.test(entry));
+    }
+}

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileParticipationFilterTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileParticipationFilterTest.java
@@ -1,0 +1,53 @@
+package com.sdpteam.connectout.profileList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.sdpteam.connectout.profile.Profile;
+import com.sdpteam.connectout.profile.ProfileEntry;
+import com.sdpteam.connectout.profile.RegisteredEvent;
+import com.sdpteam.connectout.profileList.filter.ProfileParticipationFilter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class ProfileParticipationFilterTest {
+
+    @Test
+    public void testParticipationFilterMatches() {
+        final ProfileParticipationFilter filter1 = new ProfileParticipationFilter("1");
+        final ProfileParticipationFilter filter2 = new ProfileParticipationFilter("2");
+        final ProfileParticipationFilter filter3 = new ProfileParticipationFilter("3");
+
+        final List<RegisteredEvent> events = new ArrayList<>();
+        events.add(new RegisteredEvent(1, "1", "title 1"));
+        events.add(new RegisteredEvent(1, "2", "title 1"));
+        events.add(new RegisteredEvent(1, "3", "title 1"));
+
+        final ProfileEntry entry = new ProfileEntry(Profile.NULL_PROFILE, events);
+
+        assertTrue(filter1.test(entry));
+        assertTrue(filter2.test(entry));
+        assertTrue(filter3.test(entry));
+    }
+
+    @Test
+    public void testParticipationFilterMismatches() {
+        final ProfileParticipationFilter filter = new ProfileParticipationFilter("x");
+
+        final List<RegisteredEvent> events = new ArrayList<>();
+        events.add(new RegisteredEvent(1, "1", "title 1"));
+        events.add(new RegisteredEvent(1, "2", "title 1"));
+        events.add(new RegisteredEvent(1, "3", "title 1"));
+
+        final ProfileEntry entry = new ProfileEntry(Profile.NULL_PROFILE, events);
+
+        assertFalse(filter.test(entry));
+    }
+}

--- a/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileRatingFilterTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/profileList/ProfileRatingFilterTest.java
@@ -1,0 +1,47 @@
+package com.sdpteam.connectout.profileList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.sdpteam.connectout.profile.Profile;
+import com.sdpteam.connectout.profile.ProfileEntry;
+import com.sdpteam.connectout.profileList.filter.ProfileRatingFilter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+@RunWith(AndroidJUnit4.class)
+public class ProfileRatingFilterTest {
+
+    @Test
+    public void testRatingFilterMatches() {
+        final ProfileRatingFilter filter1 = new ProfileRatingFilter(0, 5);
+        final ProfileRatingFilter filter2 = new ProfileRatingFilter(2, 3);
+        final ProfileRatingFilter filter3 = new ProfileRatingFilter(2.5, 2.5);
+        final ProfileRatingFilter filter4 = new ProfileRatingFilter(-1, 3);
+
+        final Profile profile = new Profile("", "", "", "", Profile.Gender.MALE, 2.5, 1, "");
+        final ProfileEntry entry = new ProfileEntry(profile, new ArrayList<>());
+
+        assertTrue(filter1.test(entry));
+        assertTrue(filter2.test(entry));
+        assertTrue(filter3.test(entry));
+        assertTrue(filter4.test(entry));
+    }
+
+    @Test
+    public void testRatingFilterMismatches() {
+        final ProfileRatingFilter filter1 = new ProfileRatingFilter(3, 2);
+        final ProfileRatingFilter filter2 = new ProfileRatingFilter(3, 3);
+
+        final Profile profile = new Profile("", "", "", "", Profile.Gender.MALE, 2.5, 1, "");
+        final ProfileEntry entry = new ProfileEntry(profile, new ArrayList<>());
+
+        assertFalse(filter1.test(entry));
+        assertFalse(filter2.test(entry));
+    }
+}

--- a/app/src/main/java/com/sdpteam/connectout/profile/ProfileEntry.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/ProfileEntry.java
@@ -2,6 +2,12 @@ package com.sdpteam.connectout.profile;
 
 import java.util.List;
 
+/**
+ * A profile entry represents one entry of the users collection in the Firebase.
+ * This class basically reflects the current structure in Firebase. It is used for profiles
+ * filtering as we can filter by the attributes of a profile and its participation
+ * to some specific events as well.
+ */
 public class ProfileEntry {
 
     private final Profile profile;

--- a/app/src/main/java/com/sdpteam/connectout/profile/ProfileEntry.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/ProfileEntry.java
@@ -1,0 +1,22 @@
+package com.sdpteam.connectout.profile;
+
+import java.util.List;
+
+public class ProfileEntry {
+
+    private final Profile profile;
+    private final List<RegisteredEvent> registeredEvents;
+
+    public ProfileEntry(Profile profile, List<RegisteredEvent> registeredEvents) {
+        this.profile = profile;
+        this.registeredEvents = registeredEvents;
+    }
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public List<RegisteredEvent> getRegisteredEvents() {
+        return registeredEvents;
+    }
+}

--- a/app/src/main/java/com/sdpteam/connectout/profile/ProfileFirebaseDataSource.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/ProfileFirebaseDataSource.java
@@ -13,9 +13,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
-import com.sdpteam.connectout.event.EventFirebaseDataSource;
 import com.sdpteam.connectout.profileList.filter.ProfileFilter;
-import com.sdpteam.connectout.profileList.filter.ProfileParticipationFilter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,19 +96,28 @@ public class ProfileFirebaseDataSource implements ProfileDataSource, RegisteredE
     public CompletableFuture<List<Profile>> getProfilesByFilter(ProfileFilter filter) {
         final CompletableFuture<List<Profile>> future = new CompletableFuture<>();
 
-        if (filter instanceof ProfileParticipationFilter) {
-            return new EventFirebaseDataSource().getEvent(((ProfileParticipationFilter) filter).eventId)
-                    .thenCompose(e -> fetchProfiles(e.getParticipants()));
-        }
+        firebaseRef.child(USERS).limitToFirst(MAX_PROFILES_FETCHED).get().addOnCompleteListener(t -> {
+            final List<Profile> result = new ArrayList<>();
 
-        final Query query = filter.buildQuery(firebaseRef.child(USERS)).limitToFirst(MAX_PROFILES_FETCHED);
-
-        query.get().addOnCompleteListener(t -> {
-                    final List<Profile> result = new ArrayList<>();
-                    t.getResult().getChildren().forEach(snapshot -> result.add(snapshot.child(PROFILE).getValue(Profile.class)));
-                    future.complete(result);
+            for (DataSnapshot snapshot : t.getResult().getChildren()) {
+                final Profile profile = snapshot.child(PROFILE).getValue(Profile.class);
+                if (profile == null || profile.getNameLowercase() == null) {
+                    continue;
                 }
-        );
+                final List<RegisteredEvent> registeredEvents = new ArrayList<>();
+
+                for (DataSnapshot child : snapshot.child(REGISTERED_EVENTS).getChildren()) {
+                    final RegisteredEvent event = child.getValue(RegisteredEvent.class);
+                    registeredEvents.add(event);
+                }
+
+                final ProfileEntry entry = new ProfileEntry(profile, registeredEvents);
+                if (filter.test(entry)) {
+                    result.add(entry.getProfile());
+                }
+            }
+            future.complete(result);
+        });
         return future;
     }
 

--- a/app/src/main/java/com/sdpteam/connectout/profile/ProfileFirebaseDataSource.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/ProfileFirebaseDataSource.java
@@ -96,21 +96,27 @@ public class ProfileFirebaseDataSource implements ProfileDataSource, RegisteredE
     public CompletableFuture<List<Profile>> getProfilesByFilter(ProfileFilter filter) {
         final CompletableFuture<List<Profile>> future = new CompletableFuture<>();
 
+        // Fetch all the users (profile + its registered events)
         firebaseRef.child(USERS).limitToFirst(MAX_PROFILES_FETCHED).get().addOnCompleteListener(t -> {
             final List<Profile> result = new ArrayList<>();
 
+            // Iterate over the results
             for (DataSnapshot snapshot : t.getResult().getChildren()) {
+
+                // Get the profile class
                 final Profile profile = snapshot.child(PROFILE).getValue(Profile.class);
                 if (profile == null || profile.getNameLowercase() == null) {
                     continue;
                 }
-                final List<RegisteredEvent> registeredEvents = new ArrayList<>();
 
+                // Get the registered events list
+                final List<RegisteredEvent> registeredEvents = new ArrayList<>();
                 for (DataSnapshot child : snapshot.child(REGISTERED_EVENTS).getChildren()) {
                     final RegisteredEvent event = child.getValue(RegisteredEvent.class);
                     registeredEvents.add(event);
                 }
 
+                // Check if the entry satisfies the filter
                 final ProfileEntry entry = new ProfileEntry(profile, registeredEvents);
                 if (filter.test(entry)) {
                     result.add(entry.getProfile());

--- a/app/src/main/java/com/sdpteam/connectout/profile/RegisteredEvent.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/RegisteredEvent.java
@@ -1,0 +1,30 @@
+package com.sdpteam.connectout.profile;
+
+public class RegisteredEvent {
+    private final long eventDate;
+    private final String eventId;
+    private final String eventTitle;
+    public static final RegisteredEvent NULL_REGISTERED_EVENT = new RegisteredEvent();
+
+    private RegisteredEvent() {
+        this(0, "", "");
+    }
+
+    public RegisteredEvent(long eventDate, String eventId, String eventTitle) {
+        this.eventDate = eventDate;
+        this.eventId = eventId;
+        this.eventTitle = eventTitle;
+    }
+
+    public long getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public String getEventTitle() {
+        return eventTitle;
+    }
+}

--- a/app/src/main/java/com/sdpteam/connectout/profile/RegisteredEvent.java
+++ b/app/src/main/java/com/sdpteam/connectout/profile/RegisteredEvent.java
@@ -1,5 +1,9 @@
 package com.sdpteam.connectout.profile;
 
+/**
+ * This class represents the child Users/RegisteredEvents in the Firebase structure.
+ * It is used to build back the {@link ProfileEntry} when we fetch the profiles.
+ */
 public class RegisteredEvent {
     private final long eventDate;
     private final String eventId;

--- a/app/src/main/java/com/sdpteam/connectout/profileList/CommunityFragment.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/CommunityFragment.java
@@ -22,9 +22,7 @@ public class CommunityFragment extends DrawerFragment {
 
         final Toolbar toolbar = view.findViewById(R.id.user_list_toolbar);
         final Button filterBtn = view.findViewById(R.id.user_list_button);
-        setupToolBar(filterBtn, toolbar, "Filter", v -> {
-            // TODO open dialog
-        });
+        setupToolBar(filterBtn, toolbar, "Filter", null); // to hide/remove button
 
         final FilteredProfileListFragment profilesFragment = new FilteredProfileListFragment();
         getChildFragmentManager().beginTransaction().replace(R.id.container_users_listview, profilesFragment).commit();

--- a/app/src/main/java/com/sdpteam/connectout/profileList/FilteredProfileListFragment.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/FilteredProfileListFragment.java
@@ -41,7 +41,7 @@ public class FilteredProfileListFragment extends Fragment {
 
         searchRunnable = () -> {
             final ProfileNameFilter nameFilter = new ProfileNameFilter(searchFilter.getText().toString());
-            viewModel.setFilter(nameFilter);
+            viewModel.setFilter(baseFilter.and(nameFilter));
             viewModel.refreshProfiles();
         };
 

--- a/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileFilter.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileFilter.java
@@ -1,18 +1,23 @@
 package com.sdpteam.connectout.profileList.filter;
 
-import static com.sdpteam.connectout.profile.ProfileFirebaseDataSource.PROFILE;
+import com.sdpteam.connectout.profile.ProfileEntry;
 
-import com.google.firebase.database.Query;
+import java.util.function.Predicate;
 
-public interface ProfileFilter {
+public interface ProfileFilter extends Predicate<ProfileEntry> {
 
-    ProfileFilter NONE = root -> root.orderByChild(PROFILE + "/nameLowercase");
+    ProfileFilter NONE = entry -> true;
+
+    @Override
+    boolean test(ProfileEntry entry);
 
     /**
-     * Build up a more constrained query based on top of some root query
+     * Combine two filters with the "AND" operator.
      *
-     * @param root (Query): query on which we add constraints
-     * @return new query with additional filters
+     * @param otherFilter (ProfileFilter): the other filter to combine with.
+     * @return new combined filter.
      */
-    Query buildQuery(Query root);
+    default ProfileFilter and(ProfileFilter otherFilter) {
+        return entry -> test(entry) && otherFilter.test(entry);
+    }
 }

--- a/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileNameFilter.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileNameFilter.java
@@ -1,15 +1,12 @@
 package com.sdpteam.connectout.profileList.filter;
 
-import static com.sdpteam.connectout.profile.ProfileFirebaseDataSource.PROFILE;
-
-import com.google.firebase.database.Query;
+import com.sdpteam.connectout.profile.ProfileEntry;
 
 /**
  * Filters participants by their name.
  */
 public class ProfileNameFilter implements ProfileFilter {
 
-    private final static String QUERY_END = "\uf8ff";
     private final String text;
 
     public ProfileNameFilter(String text) {
@@ -17,9 +14,7 @@ public class ProfileNameFilter implements ProfileFilter {
     }
 
     @Override
-    public Query buildQuery(Query root) {
-        // The regex is used to ensure that we retrieve all names starting with the given string
-        return root.orderByChild(PROFILE + "/nameLowercase")
-                .startAt(text).endAt(text + QUERY_END);
+    public boolean test(ProfileEntry entry) {
+        return entry.getProfile().getNameLowercase().contains(text);
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileParticipationFilter.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileParticipationFilter.java
@@ -1,6 +1,6 @@
 package com.sdpteam.connectout.profileList.filter;
 
-import com.google.firebase.database.Query;
+import com.sdpteam.connectout.profile.ProfileEntry;
 
 public class ProfileParticipationFilter implements ProfileFilter {
 
@@ -11,10 +11,7 @@ public class ProfileParticipationFilter implements ProfileFilter {
     }
 
     @Override
-    public Query buildQuery(Query root) {
-        if (eventId == null || eventId.isEmpty()) {
-            return root;
-        }
-        return root.orderByChild("RegisteredEvents/eventId").equalTo(eventId);
+    public boolean test(ProfileEntry entry) {
+        return entry.getRegisteredEvents().stream().anyMatch(registeredEvent -> registeredEvent.getEventId().equals(eventId));
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileRatingFilter.java
+++ b/app/src/main/java/com/sdpteam/connectout/profileList/filter/ProfileRatingFilter.java
@@ -1,6 +1,6 @@
 package com.sdpteam.connectout.profileList.filter;
 
-import com.google.firebase.database.Query;
+import com.sdpteam.connectout.profile.ProfileEntry;
 
 /**
  * Filters participants by their ratings within a custom range
@@ -20,7 +20,7 @@ public class ProfileRatingFilter implements ProfileFilter {
     }
 
     @Override
-    public Query buildQuery(Query root) {
-        return root.startAt(minRating).endAt(maxRating);
+    public boolean test(ProfileEntry entry) {
+        return minRating <= entry.getProfile().getRating() && entry.getProfile().getRating() <= maxRating;
     }
 }


### PR DESCRIPTION
This PR aims to fix the bug #147 

After lot of investigation and trials, I decided to bring all the profiles to the frontend and filter on them directly. Combining filters on Firebase queries is not permitted as it requires to make multiple order by child. The solution proposed here is very similar and inspired from the events filtering I did in a previous sprint.