### PR TITLE
Upload image preview of event (at creation page)

### DIFF
--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventTest.java
@@ -3,6 +3,7 @@ package com.sdpteam.connectout.event;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.android.gms.maps.model.LatLng;
@@ -76,5 +77,10 @@ public class EventTest {
 
         assertFalse(TEST_EVENT.isInterested("1"));
         assertTrue(TEST_EVENT.hasJoined("1"));
+    }
+
+    @Test
+    public void testImageUrl() {
+        assertNull(TEST_EVENT.getPreviewImageUrl());
     }
 }

--- a/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/event/EventsActivityTest.java
@@ -39,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
@@ -53,7 +54,7 @@ public class EventsActivityTest {
     @Before
     public void setup() {
         Intents.init();
-        eventDs.saveEvent(new Event(eventId, "Title", "Desc", null, "aa"));
+        eventDs.saveEvent(new Event(eventId, "Title", "Desc", null, "aa", new ArrayList<>(), new ArrayList<>(), 0, new Event.EventRestrictions(), "https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Flag_of_Switzerland_%28Pantone%29.svg/512px-Flag_of_Switzerland_%28Pantone%29.svg.png"));
         waitABit();
     }
 

--- a/app/src/androidTest/java/com/sdpteam/connectout/post/view/PostsActivityTest.java
+++ b/app/src/androidTest/java/com/sdpteam/connectout/post/view/PostsActivityTest.java
@@ -46,10 +46,8 @@ public class PostsActivityTest {
     @BeforeClass
     public static void setUpClass() {
         imagesUrls.clear();
-        imagesUrls.add("https://firebasestorage.googleapis.com/v0/b/my-project-test-a847f.appspot.com/o/1683269814271_40078ef6-3886-4c15-b013-940b8d3f1614" +
-                ".jpg?alt=media&token=c5abae50-d2af-4361-bb75-d975f8460a6d");
-        imagesUrls.add("https://firebasestorage.googleapis.com/v0/b/my-project-test-a847f.appspot.com/o/1683269290710_5e3659ce-9aea-4f90-aea2-64eb941d6a6c" +
-                ".jpg?alt=media&token=590a4df0-12c1-491a-9b89-f621c8f2bbe3");
+        imagesUrls.add("https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Flag_of_Switzerland_%28Pantone%29.svg/512px-Flag_of_Switzerland_%28Pantone%29.svg.png");
+        imagesUrls.add("https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Flag_of_Switzerland_%28Pantone%29.svg/512px-Flag_of_Switzerland_%28Pantone%29.svg.png");
 
         assertTrue(fJoin(new PostFirebaseDataSource().savePost(TEST_POST_EVENT)).isSuccess());
         assertTrue(fJoin(new PostFirebaseDataSource().savePost(TEST_POST_EVENT1)).isSuccess());

--- a/app/src/main/java/com/sdpteam/connectout/event/Event.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/Event.java
@@ -2,11 +2,11 @@ package com.sdpteam.connectout.event;
 
 import static com.sdpteam.connectout.profile.EditProfileActivity.NULL_USER;
 
-import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
-
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
+
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
 
 /**
  * This class describes an event
@@ -24,6 +24,8 @@ public class Event {
     private final List<String> interestedParticipants;
     private final long date;
     private final EventRestrictions restrictions;
+
+    private final String previewImageUrl;
 
     private Event() {
         this(NULL_USER, "NullTitle", "NullDescription", new GPSCoordinates(0, 0), NULL_USER, new ArrayList<>(), new ArrayList<>(), 0);
@@ -51,7 +53,7 @@ public class Event {
                  List<String> participants,
                  List<String> interestedParticipants,
                  long date) {
-        this(id, title, description, coordinates, organizer, participants, interestedParticipants, date, new EventRestrictions());
+        this(id, title, description, coordinates, organizer, participants, interestedParticipants, date, new EventRestrictions(), null);
     }
 
     public Event(String id,
@@ -62,7 +64,8 @@ public class Event {
                  List<String> participants,
                  List<String> interestedParticipants,
                  long date,
-                 EventRestrictions restrictions) {
+                 EventRestrictions restrictions,
+                 String previewImageUrl) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -72,6 +75,7 @@ public class Event {
         this.interestedParticipants = interestedParticipants;
         this.date = date;
         this.restrictions = restrictions;
+        this.previewImageUrl = previewImageUrl;
     }
 
     public String getId() {
@@ -116,6 +120,10 @@ public class Event {
 
     public EventRestrictions getRestrictions() {
         return restrictions;
+    }
+
+    public String getPreviewImageUrl() {
+        return previewImageUrl;
     }
 
     /**

--- a/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorViewModel.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/creator/EventCreatorViewModel.java
@@ -1,10 +1,22 @@
 package com.sdpteam.connectout.event.creator;
 
-import androidx.lifecycle.MutableLiveData;
+import static java.util.Collections.singletonList;
 
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
+import com.sdpteam.connectout.authentication.AuthenticatedUser;
+import com.sdpteam.connectout.authentication.GoogleAuth;
 import com.sdpteam.connectout.event.Event;
 import com.sdpteam.connectout.event.EventDataSource;
 import com.sdpteam.connectout.event.nearbyEvents.EventsViewModel;
+import com.sdpteam.connectout.event.nearbyEvents.map.GPSCoordinates;
+import com.sdpteam.connectout.notifications.EventNotificationManager;
+import com.sdpteam.connectout.profile.EditProfileActivity;
+import com.sdpteam.connectout.remoteStorage.FileStorageFirebase;
+
+import android.net.Uri;
+import androidx.lifecycle.MutableLiveData;
 
 public class EventCreatorViewModel extends EventsViewModel {
     private final EventDataSource model;
@@ -29,10 +41,41 @@ public class EventCreatorViewModel extends EventsViewModel {
     }
 
     public Boolean saveEvent(Event event) {
-        return model.saveEvent(event);
+        boolean result = model.saveEvent(event);
+        if (result) {
+            subscribeToEvent(event);
+        }
+        return result;
+    }
+
+    /**
+     * @param title       (String): title of the event
+     * @param coordinates (GPSCoordinates): position of the event
+     * @param description (String): description of the event
+     */
+    public void saveEvent(String title, GPSCoordinates coordinates, String description, long date, String imageUrl) {
+        AuthenticatedUser user = new GoogleAuth().loggedUser();
+        String ownerId = (user == null) ? EditProfileActivity.NULL_USER : user.uid;
+
+        ArrayList<String> participants = new ArrayList<>(singletonList(ownerId));
+        Event newEvent = new Event(getUniqueId(), title, description, coordinates, ownerId, participants, new ArrayList<>(), date, new Event.EventRestrictions(), imageUrl);
+
+        saveEvent(newEvent);
+    }
+
+    private void subscribeToEvent(Event event) {
+        EventNotificationManager manager = new EventNotificationManager();
+        manager.subscribeToEventTopic(event.getId());
     }
 
     public String getUniqueId() {
         return model.getUniqueId();
+    }
+
+    public CompletableFuture<String> uploadImage(Uri selectedImageUri) {
+        if (selectedImageUri == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return new FileStorageFirebase().uploadFile(selectedImageUri, "jpg").thenApply(Uri::toString);
     }
 }

--- a/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
+++ b/app/src/main/java/com/sdpteam/connectout/event/nearbyEvents/list/EventsAdapter.java
@@ -1,16 +1,6 @@
 package com.sdpteam.connectout.event.nearbyEvents.list;
 
-import android.content.Context;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.ImageButton;
-import android.widget.ImageView;
-import android.widget.TextView;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import java.util.List;
 
 import com.sdpteam.connectout.R;
 import com.sdpteam.connectout.event.Event;
@@ -19,7 +9,16 @@ import com.sdpteam.connectout.profile.ProfileActivity;
 import com.sdpteam.connectout.profile.ProfileFirebaseDataSource;
 import com.squareup.picasso.Picasso;
 
-import java.util.List;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * It is responsible for creating and managing the views for a list of events.
@@ -80,8 +79,12 @@ public class EventsAdapter extends ArrayAdapter<Event> {
         loadOrganizerProfileImage(orgProfileId, profileImageButton);
         profileImageButton.setOnClickListener(v -> ProfileActivity.openProfile(getContext(), orgProfileId));
 
-        ImageView eventImage = view.findViewById(R.id.event_list_event_image);//TODO set event image
+        ImageView eventImage = view.findViewById(R.id.event_list_event_image);
         view.setOnClickListener(v -> EventActivity.openEvent(getContext(), event.getId()));
+        final String imageUrl = event.getPreviewImageUrl();
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            Picasso.get().load(imageUrl).into(eventImage);
+        }
         return view;
     }
 }

--- a/app/src/main/res/layout/activity_event_creator.xml
+++ b/app/src/main/res/layout/activity_event_creator.xml
@@ -121,12 +121,34 @@
 
         </RelativeLayout>
 
+        <TextView
+                android:id="@+id/selectImageLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:text="Event image"
+                android:layout_below="@+id/event_creator_select_time"
+                android:layout_alignParentStart="true"
+                android:layout_marginStart="16dp"
+                android:textSize="18sp"
+                android:paddingVertical="12dp"/>
+
+        <FrameLayout
+                android:id="@+id/event_creator_selectImage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Add location"
+                android:minHeight="50dp"
+                android:layout_below="@+id/event_creator_select_time"
+                android:layout_toRightOf="@id/selectImageLabel"
+                android:layout_marginStart="6dp"
+                android:layout_alignParentEnd="true" />
+
         <RelativeLayout
                 android:id="@+id/event_creator_fragment_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:defaultNavHost="true"
-                android:layout_below="@+id/event_creator_select_time"
+                android:layout_below="@+id/event_creator_selectImage"
 
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"


### PR DESCRIPTION
Solving #149, now we can select a image for an event and it will be displayed in the list views when there are events listed.

Event creator looks like that now:
<img src="https://github.com/ConnectOut-sdp/sdp2023/assets/31776627/9c64ded1-27e2-459c-b96d-3c370e65f2f3" width="150">

When clicking on the button save it shows information to the user that it is doing some work behind.
